### PR TITLE
Add Providence EOL Club info, Est. date to layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,7 +28,7 @@
           <li><a href="/pittsburgh">Pittsburgh <small>TBA</small></a></li>
           <li><a href="/boston">Boston <small>Est. Oct 2012</small></a></li>
           <li><a href="/new_york">NYC <small>TBA</small></a></li>
-          <li><a href="/providence">Providence <small>TBA</small></a></li>
+          <li><a href="/providence">Providence <small>Est. Mar 2012</small></a></li>
           <li><a href="/birmingham">Birmingham, AL <small>TBA</small></a></li>
           <li><a href="/fortwayne">Fort Wayne, IN <small>TBA</small></a></li>
           <li><a href="/yours">Yours?</a></li>

--- a/providence/index.markdown
+++ b/providence/index.markdown
@@ -3,8 +3,25 @@ layout: default
 title: OpenHack - Providence
 ---
 
-## Providence
+## Providence - End of Line Club
 
-### Info
+Monthly Providence, RI hacknight. Code, design, and collaborate with other local developers to a backdrop of electronic music. Bring your laptop and a project to work on. Arrive whenever you can. Pizza and drinks provided.
+
+[EOLclub.org](http://eolclub.org) and [@EOLclub](https://twitter.com/EOLclub) to get more info and RSVP.
+
+### Next meetup
+
+* Monday, November 5th, 2012 from 6pm–11pm at [Basics Group](http://basicsgroup.com)
+
+### Past meetups
+
+* October 1st, 2012 - 6 attendees
+* August 6th, 2012 - 12 attendees
+* May 21st, 2012 - 6 attendees
+* April 30th, 2012 - 8 attendees
+* March 26th, 2012 - 20 attendees
+
+
+## Providence - Other OpenHacks
 
 Coming soon! Bug [@cmeiklejohn](http://github.com/cmeiklejohn) for more info.


### PR DESCRIPTION
Added End of Line Club meetup info to Providence, along with an Est. date on the default layout.

@cmeiklejohn had already setup the Providence page, but didn't add any content yet. I'm not sure what meetup this was done for, so I left it as a second block on the page.
