### PR TITLE
Update Providence after 11/5 EOLclub meetup

### DIFF
--- a/providence/index.markdown
+++ b/providence/index.markdown
@@ -3,25 +3,23 @@ layout: default
 title: OpenHack - Providence
 ---
 
-## Providence - End of Line Club
+## Providence
 
-Monthly Providence, RI hacknight. Code, design, and collaborate with other local developers to a backdrop of electronic music. Bring your laptop and a project to work on. Arrive whenever you can. Pizza and drinks provided.
+### Info
+
+EOLclub is a monthly Providence, RI hacknight. Code, design, and collaborate with other local developers to a backdrop of electronic music. Bring your laptop and a project to work on. Arrive whenever you can. Pizza and drinks provided.
 
 [EOLclub.org](http://eolclub.org) and [@EOLclub](https://twitter.com/EOLclub) to get more info and RSVP.
 
 ### Next meetup
 
-* Monday, November 5th, 2012 from 6pm–11pm at [Basics Group](http://basicsgroup.com)
+* Monday, December 3rd, 2012 from 6pm–11pm at [Basics Group](http://basicsgroup.com)
 
 ### Past meetups
 
+* November 5th, 2012 - 10 attendees
 * October 1st, 2012 - 6 attendees
 * August 6th, 2012 - 12 attendees
 * May 21st, 2012 - 6 attendees
 * April 30th, 2012 - 8 attendees
 * March 26th, 2012 - 20 attendees
-
-
-## Providence - Other OpenHacks
-
-Coming soon! Bug [@cmeiklejohn](http://github.com/cmeiklejohn) for more info.


### PR DESCRIPTION
- Add Info H3 for consistency with other cities
- Update Providence EOLclub after 11/5 meeting
- Remove "other" PVD OpenHacks per @cmeiklejohn

This is a squashed commit from the [update_pvd_v7](https://github.com/ilikepi/openhack.github.com/commits/update_pvd_v7) branch.

Additionally, as the co-organizer of EOLclub with @dpie, could I please be added as a Collaborator?
