### PR TITLE
Taipei geocode fix

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -77,8 +77,8 @@ cities:
     longitude: -71.4128343
 - taipei: 
     name: Taipei, Taiwan
-    latitude: 25.091075
-    longitude: 121.5598345
+    latitude: 25.04684
+    longitude: 121.51737
 - toronto: 
     name: Toronto, ON
     latitude: 43.653226


### PR DESCRIPTION
Google Maps and other geocoders report Taipei City at a location which
is the suburbs and actually not really the city itself (Neihu). Fix
the location to the city core, which should be more accurate,
for the future, or until we have a know location for the events.
