### PR TITLE
Rakefile: reorganize build related tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,18 +1,18 @@
-desc "compile and run the site"
-task :default do
-  pids = [
-    spawn("jekyll"),
-    spawn("scss --watch assets:stylesheets"),
-  ]
+task :default => [:build]
 
-  trap "INT" do
-    Process.kill "INT", *pids
-    exit 1
-  end
+desc "Build site"
+task :build => [:clean] do |task, args|
+  system("jekyll --no-server --no-auto")
+end
 
-  loop do
-    sleep 1
-  end
+desc "Preview site"
+task :preview => [:clean] do
+  system("jekyll --server --auto")
+end
+
+desc "Remove compiled directory"
+task :clean do
+  system "rm -rf _site"
 end
 
 desc "Generate a page for your city!"


### PR DESCRIPTION
Make the default task just a build, to be able to run it more programically.
The previous default (monitoring mode) is now "preview" task.
Removed sass, as it seems there are no assets that need it (only have
CSS at the moment), and "jekyll --auto --server" can deal with monitoring
for changes

This is partly in preparation to integrate with Travis-CI.
