### PR TITLE
Rakefile: reorganize build related tasks (v2)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,9 +7,17 @@ Get started!
     gem install bundler
     bundle
 
-Run the site with:
+Compile the site and start preview web server by running
 
-    rake
+    rake preview
+
+and see the the result at [http://localhost:4000](http://localhost:4000)
+
+## Rake tasks
+
+ * `rake build` cleans any previus builds and rebuild the site (default task, run at `rake`)
+ * `rake clean` clean previous builds
+ * `rake preview`: clean, build and preview
 
 ## License
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,18 +1,18 @@
-desc "compile and run the site"
-task :default do
-  pids = [
-    spawn("jekyll"),
-    spawn("scss --watch assets:stylesheets"),
-  ]
+task :default => [:build]
 
-  trap "INT" do
-    Process.kill "INT", *pids
-    exit 1
-  end
+desc "Build site"
+task :build => [:clean] do
+  system("jekyll --no-server --no-auto")
+end
 
-  loop do
-    sleep 1
-  end
+desc "Preview site"
+task :preview => [:clean, :build] do
+  system("jekyll --server --auto")
+end
+
+desc "Remove compiled directory"
+task :clean do
+  system "rm -rf _site"
 end
 
 desc "Generate a page for your city!"


### PR DESCRIPTION
Make the default task just a build, to be able to run it more programically.
The previous default (monitoring mode) is now "preview" task.
Removed sass, as it seems there are no assets that need it (only have
CSS at the moment), and "jekyll --auto --server" can deal with monitoring
for changes

(added rake tasks to Readme)
