### PR TITLE
Changed OpenHack Waterloo organizer

### DIFF
--- a/waterloo/index.markdown
+++ b/waterloo/index.markdown
@@ -7,7 +7,7 @@ title: OpenHack - Waterloo, ON
 
 Waterloo OpenHack meetup coming soon!
 
-For more info bug [@mkhDev](http://twitter.com/mkhDev).
+For more info bug [@bnmrrs](http://twitter.com/bnmrrs) or [@ArtBarnLabs](http://twitter.com/ArtBarnLabs) .
 
 ### Next meetups
 


### PR DESCRIPTION
mkhDev doesn't seem to be active anymore so @bnmrrs and @artbarnlabs are going to take it over.
