### PR TITLE
Update event links to point to Meetup vs. Eventbrite

### DIFF
--- a/fortwayne/index.markdown
+++ b/fortwayne/index.markdown
@@ -12,7 +12,8 @@ title: OpenHack - Fort Wayne, IN
 [Squaremouth](http://www.squaremouth.com) is hosting OpenHack events in
 our Fort Wayne office.
 
-We'll keep our [events on Eventbrite](http://openhackfw.eventbrite.com)
+We'll keep our [events on
+Meetup](http://www.meetup.com/OpenHack-Fort-Wayne)
 and would love to have you join us! Be sure to RSVP for the event so we
 know to get enough food.
 
@@ -23,5 +24,6 @@ you're thinking!
 ### Next meetup
 
 We usually hold our OpenHacks on the second Thursday of each month, but
-you should really [check our Eventbrite page](http://openhackfw.eventbrite.com)
+you should really [check our Meetup
+page](http://www.meetup.com/OpenHack-Fort-Wayne)
 which will always have the next OpenHack event.


### PR DESCRIPTION
This pull request updates event links on the Fort Wayne OpenHack page.  We have created a Meetup page to handle announcing and RSVP for OpenHack Fort Wayne so the links have been updated to point to the new Meetup page.
