### PR TITLE
Use Kramdown in favor of Maruku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'jekyll'
-gem 'maruku'
 gem 'rake'
 gem 'sass'
 gem 'geocoder'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,5 @@ PLATFORMS
 DEPENDENCIES
   geocoder
   jekyll
-  maruku
   rake
   sass

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 ---
 server: true
-markdown: maruku
+markdown: kramdown
 auto: true
 cities:
 - albuquerque:


### PR DESCRIPTION
- Maruku is no longer maintained
  - http://benhollis.net/blog/2013/10/20/maruku-is-obsolete/
- Jekyll has replaced Maruku with Kramdown as the default
  - https://github.com/jekyll/jekyll/pull/1988/files
