### PR TITLE
Add OpenHack Haverhill, MA

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -135,6 +135,10 @@ cities:
     name: Green Bay, WI
     latitude: 44.51915899999999
     longitude: -88.019826
+- haverhill:
+    name: Haverhill, MA
+    latitude: 42.7754552
+    longitude: -71.085962
 - honolulu:
     name: Honolulu, HI
     latitude: 21.3069444

--- a/haverhill/index.markdown
+++ b/haverhill/index.markdown
@@ -8,8 +8,8 @@ title: OpenHack - Haverhill, MA
 ### Info
 
 Haverhill OpenHack is hosted at the Haverhill Hackspace located downtown at 143
-Essex Street in Suite 600. It is one of two monthly [Haverhill Hackers][meetup]
-meetups.
+Essex Street on the sixth floor in Suite 600. It is one of two monthly
+[Haverhill Hackers][meetup] meetups.
 
 Bring your laptop, charger, and anything else you may want to work on.
 

--- a/haverhill/index.markdown
+++ b/haverhill/index.markdown
@@ -1,0 +1,33 @@
+---
+layout: default
+title: OpenHack - Haverhill, MA
+---
+
+## Haverhill, MA
+
+### Info
+
+Haverhill OpenHack is hosted at the Haverhill Hackspace located downtown at 143
+Essex Street in Suite 600. It is one of two monthly [Haverhill Hackers][meetup]
+meetups.
+
+Bring your laptop, charger, and anything else you may want to work on.
+
+Pizza, beer, and coffee are often provided to fuel the creativity.
+
+### Schedule
+
+* 6:15PM - Welcome & Introductions
+* 6:30PM - Organize & Start hacking
+* 9:00PM - (Optional) Share what you hacked on!
+
+### Upcoming meetups
+
+* [March 2016](http://www.meetup.com/HaverhillHackers/events/229411471)
+
+### Past meetups
+
+* [February 2016](http://www.meetup.com/HaverhillHackers/events/228664826/)
+
+
+[meetup]: http://www.meetup.com/HaverhillHackers


### PR DESCRIPTION
I've added a listing for OpenHack in Haverhill, MA. 

This is part of an established meetup group known as the [Haverhill Hackers](http://www.meetup.com/HaverhillHackers/).