### PR TITLE
Bump Ruby and Gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'jekyll'
+ruby "2.7.4"
+
+gem 'jekyll', '~> 3.8.6'
 gem 'rake'
 gem 'sass'
 gem 'geocoder'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,34 +1,69 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    albino (1.3.3)
-      posix-spawn (>= 0.3.6)
-    classifier (1.3.3)
-      fast-stemmer (>= 1.0.0)
-    directory_watcher (1.4.1)
-    fast-stemmer (1.0.1)
-    geocoder (1.1.4)
-    jekyll (0.11.2)
-      albino (~> 1.3)
-      classifier (~> 1.3)
-      directory_watcher (~> 1.1)
-      kramdown (~> 0.13)
-      liquid (~> 2.3)
-      maruku (~> 0.5)
-    kramdown (0.14.0)
-    liquid (2.4.1)
-    maruku (0.6.1)
-      syntax (>= 1.0.0)
-    posix-spawn (0.3.6)
-    rake (0.9.2.2)
-    sass (3.2.1)
-    syntax (1.0.0)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    colorator (1.1.0)
+    concurrent-ruby (1.1.9)
+    em-websocket (0.5.2)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.6.0)
+    eventmachine (1.2.7)
+    ffi (1.15.3)
+    forwardable-extended (2.6.0)
+    geocoder (1.6.7)
+    http_parser.rb (0.6.0)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
+    jekyll (3.8.7)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (~> 0.7)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 1.14)
+      liquid (~> 4.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (>= 1.7, < 4)
+      safe_yaml (~> 1.0)
+    jekyll-sass-converter (1.5.2)
+      sass (~> 3.4)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    kramdown (1.17.0)
+    liquid (4.0.3)
+    listen (3.6.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mercenary (0.3.6)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (4.0.6)
+    rake (13.0.6)
+    rb-fsevent (0.11.0)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    rouge (3.26.0)
+    safe_yaml (1.0.5)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
 
 PLATFORMS
-  ruby
+  arm64-darwin-20
 
 DEPENDENCIES
   geocoder
-  jekyll
+  jekyll (~> 3.8.6)
   rake
   sass
+
+RUBY VERSION
+   ruby 2.7.4p191
+
+BUNDLED WITH
+   2.2.23

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 desc "compile and run the site"
 task :default do
   pids = [
-    spawn("jekyll"),
+    spawn("jekyll serve"),
     spawn("scss --watch assets:stylesheets"),
   ]
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,5 @@
 ---
-server: true
 markdown: kramdown
-auto: true
 cities:
 - albuquerque:
     name: Albuquerque, NM


### PR DESCRIPTION
When I pulled the site down just now and followed the instructions to get it running, nothing worked. I tried Ruby 2.7 and then 2.6 and just got Forbidden and Not Found errors from Webrick.

Given that the site was running super old versions of everything, I figured it might be wise to bundle update to more recent versions. I updated to Jekyll 3.8.x because 4.0.0 had some deprecations I didn't want to figure out around Kramdown. The configuration options I removed weren't needed anymore and the Rakefile was updated to reflect the new way of invoking jekyll to serve the site (which fixed some deprecation warnings.)

Ruby 2.7 spat out tons of warning because of the keyword argument stuff, so I just used the latest 2.6 release.

With this commit, the instructions in the README now work for me locally and we're not running ancient versions of things.